### PR TITLE
Add runnable Cognitive Catalyst demo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+*.swp
+.env
+.DS_Store
+.ipynb_checkpoints/

--- a/README.md
+++ b/README.md
@@ -1,69 +1,46 @@
-index.html- coming-soon.png<!DOCTYPE html>
-<html lang="en">
-<head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>MemoryChain – Personal AI Memory Vault</title>
-  <style>
-    body {
-      font-family: 'Segoe UI', sans-serif;
-      background: linear-gradient(to bottom, #0f0f0f, #1f1f1f);
-      color: white;
-      margin: 0;
-      padding: 0;
-      text-align: center;
-    }
-    header {
-      padding: 80px 20px 20px;
-    }
-    h1 {
-      font-size: 2.5rem;
-      margin-bottom: 0.5rem;
-      color: #6cf;
-    }
-    p {
-      font-size: 1.2rem;
-      max-width: 600px;
-      margin: 0 auto 2rem;
-      color: #ccc;
-    }
-    .button {
-      background: #6cf;
-      color: #000;
-      padding: 0.8em 1.6em;
-      font-weight: bold;
-      border-radius: 8px;
-      text-decoration: none;
-      display: inline-block;
-      margin-top: 20px;
-    }
-    .comingsoon {
-      font-size: 1rem;
-      color: #ff0;
-      margin-top: 10px;
-    }
-    img.hero {
-      max-width: 400px;
-      width: 90%;
-      margin: 40px auto;
-    }
-  </style>
-</head>
-<body>
-  <header>
-    <h1>🧠 MemoryChain</h1>
-    <p>Encrypted, persistent, AI-friendly memory — on your terms.</p>
-    <p><strong>Alpha by Louis Spires & ChatGPT</strong></p>
-    <img class="hero" src="coming-soon.png" alt="Coming Soon" />
-    <div class="comingsoon">Launching Summer 2025 · Free to explore · Built for Neural Labs</div>
-    <a class="button" href="https://github.com/neurallabs-ai/memorychain-alpha" target="_blank">View Code on GitHub</a>
-  </header>
-</body>
-</html>
+# Cognitive Catalyst Demo
 
-.
+This repository demonstrates a minimal "Living ETG" process where a node
+modifies its own behavior in response to poor performance. The concept comes
+from the idea of a **CognitiveCatalyst**—a meta-agent embedded inside each node
+that observes outcomes and can adapt the node's routine on the fly.
 
-<!---
-alfsen-create/alfsen-create is a ✨ special ✨ repository because its `README.md` (this file) appears on your GitHub profile.
-You can click the Preview link to take a look at your changes.
---->
+## Files
+
+- `demo/demo_catalyst_adapt.py` – Python example showing a self-modifying output
+  node in a small grid world.
+- `PROJECT_ATLAS_TRIALS.md` – Archived research proposal unrelated to the demo.
+
+## Running the Demo
+
+The repository bundles tiny stub implementations of `ETGGraph`, `Node`, and
+`GridEnvironment` so the example runs with no external dependencies or network
+access. Simply execute:
+
+```bash
+python demo/demo_catalyst_adapt.py
+```
+
+If you only want to verify that the script is syntactically correct, run:
+
+```bash
+python -m py_compile demo/demo_catalyst_adapt.py
+```
+
+## How It Works
+
+The output node initially uses a simple `routine_move_right` action policy. A
+`CognitiveCatalyst` inside the node tracks recent rewards. If the average reward
+over the last five steps is below `0.2`, the catalyst swaps the node's routine to
+`routine_random` and logs the change. When this happens, a message will print to
+highlight the adaptation.
+
+This repository serves as a lightweight starting point for experimenting with
+self-modifying agents and evolving task graphs.
+
+## Running Without Network Access
+
+All required modules live in this repository. Once cloned, the demo can run in
+a restricted environment with no internet connection. If you plan to install
+additional packages, do so before locking down network access.
+

--- a/demo/demo_catalyst_adapt.py
+++ b/demo/demo_catalyst_adapt.py
@@ -1,0 +1,156 @@
+import uuid
+import random
+import os
+import sys
+
+sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
+
+from etg.graph import ETGGraph, Node
+from sandbox.environment import GridEnvironment
+
+
+def make_node_id():
+    return str(uuid.uuid4())
+
+
+# Two routines the Output node can use
+
+def routine_move_right(agent, env):
+    if env.agent_pos < env.size - 1:
+        return 'right'
+    else:
+        return 'left'
+
+
+def routine_random(agent, env):
+    return random.choice(['left', 'right'])
+
+
+# The Output node's CognitiveCatalyst logic
+
+def catalyst_observe_and_adapt(output_node, recent_rewards):
+    catalyst = output_node.type_specific.get('cognitive_catalyst')
+    if not catalyst:
+        return  # No catalyst present
+    avg_reward = sum(recent_rewards) / len(recent_rewards) if recent_rewards else 0
+    if avg_reward < 0.2 and catalyst['status'] != 'mutated':
+        # Adaptation: swap routine!
+        old_routine = output_node.internal_code_chunk_ref
+        output_node.internal_code_chunk_ref = 'routine_random'
+        catalyst['status'] = 'mutated'
+        catalyst.setdefault('adaptation_log', []).append({
+            'step': len(recent_rewards),
+            'change_description': f'Swapped routine from {old_routine} to routine_random (avg_reward={avg_reward:.2f})'
+        })
+        print(f"\n\U0001F525 CognitiveCatalyst activated: Output node mutated from {old_routine} to routine_random!\n")
+
+
+def agent_step(graph: ETGGraph, env: GridEnvironment, step_count: int, recent_rewards):
+    # Percept node
+    percept = env.get_percept()
+    graph.add_node({
+        'node_id': make_node_id(),
+        'node_type': 'Percept',
+        'creation_timestamp': f'step-{step_count}',
+        'last_modified_timestamp': f'step-{step_count}',
+        'salience_score': 0.7,
+        'cognitive_thread_id_ref': 'default-thread',
+        'internal_code_chunk_ref': None,
+        'embedded_context': [float(percept)],
+        'type_specific': {'sensor_data_type': 'object_presence', 'raw_data_payload': percept}
+    })
+
+    # Output node with CognitiveCatalyst
+    if step_count == 0:
+        output_node = Node(
+            node_id=make_node_id(),
+            node_type='Output',
+            creation_timestamp=f'step-{step_count}',
+            last_modified_timestamp=f'step-{step_count}',
+            salience_score=0.8,
+            cognitive_thread_id_ref='default-thread',
+            internal_code_chunk_ref='routine_move_right',
+            embedded_context=[],
+            type_specific={
+                'action_type': 'move',
+                'cognitive_catalyst': {
+                    'catalyst_id': 'cc-output-001',
+                    'status': 'monitoring',
+                    'observables': ['recent_rewards'],
+                    'trigger_conditions': ['avg_reward < 0.2 for last 5 steps'],
+                    'adaptation_protocol': 'swap_to_routine_random'
+                }
+            }
+        )
+        graph.add_node(output_node.dict())
+        graph.agent_output_node = output_node
+    else:
+        output_node = graph.agent_output_node
+
+    # Catalyst observation and potential adaptation
+    catalyst_observe_and_adapt(output_node, recent_rewards)
+
+    # Decide action using current routine
+    routine_name = output_node.internal_code_chunk_ref
+    routine = globals()[routine_name]
+    action = routine(graph, env)
+
+    # Action node (for ETG trace)
+    graph.add_node({
+        'node_id': make_node_id(),
+        'node_type': 'Action',
+        'creation_timestamp': f'step-{step_count}',
+        'last_modified_timestamp': f'step-{step_count}',
+        'salience_score': 0.8,
+        'cognitive_thread_id_ref': 'default-thread',
+        'internal_code_chunk_ref': routine_name,
+        'embedded_context': [],
+        'type_specific': {
+            'action_type': action,
+            'action_parameters': {'step': step_count, 'agent_pos': env.agent_pos},
+            'target_interface': 'GridEnvironment'
+        }
+    })
+
+    # Execute action
+    percept, reward, done = env.take_action(action)
+    recent_rewards.append(reward)
+    if len(recent_rewards) > 5:
+        recent_rewards.pop(0)
+
+    # Memory node
+    graph.add_node({
+        'node_id': make_node_id(),
+        'node_type': 'MemoryFragment',
+        'creation_timestamp': f'step-{step_count}',
+        'last_modified_timestamp': f'step-{step_count}',
+        'salience_score': reward,
+        'cognitive_thread_id_ref': 'default-thread',
+        'internal_code_chunk_ref': None,
+        'embedded_context': [float(percept), reward],
+        'type_specific': {
+            'content_payload': f"Step {step_count}: Action={action}, Reward={reward}",
+            'temporal_tags': [f'step-{step_count}'],
+            'episodic_context_links': []
+        }
+    })
+
+    return done, action, reward
+
+
+if __name__ == "__main__":
+    graph = ETGGraph(meta={}, nodes=[], edges=[])
+    env = GridEnvironment(size=10, object_pos=7)
+    done = False
+    step = 0
+    recent_rewards = []
+    print("Agent starts searching for the object. Output node will adapt if failing for 5 steps.")
+    while not done and step < 20:
+        done, action, reward = agent_step(graph, env, step, recent_rewards)
+        print(f"Step {step}: Agent at {env.agent_pos}, action={action}, reward={reward}, done={done}")
+        step += 1
+
+    output_node = graph.agent_output_node
+    print("\n--- CognitiveCatalyst Adaptation Log ---")
+    print(output_node.type_specific['cognitive_catalyst'].get('adaptation_log', []))
+    print("\nAgent stopped at position", env.agent_pos)

--- a/etg/__init__.py
+++ b/etg/__init__.py
@@ -1,0 +1,1 @@
+from .graph import ETGGraph, Node

--- a/etg/graph.py
+++ b/etg/graph.py
@@ -1,0 +1,37 @@
+class Node:
+    def __init__(self, node_id, node_type, creation_timestamp, last_modified_timestamp,
+                 salience_score=0.0, cognitive_thread_id_ref=None,
+                 internal_code_chunk_ref=None, embedded_context=None,
+                 type_specific=None):
+        self.node_id = node_id
+        self.node_type = node_type
+        self.creation_timestamp = creation_timestamp
+        self.last_modified_timestamp = last_modified_timestamp
+        self.salience_score = salience_score
+        self.cognitive_thread_id_ref = cognitive_thread_id_ref
+        self.internal_code_chunk_ref = internal_code_chunk_ref
+        self.embedded_context = embedded_context or []
+        self.type_specific = type_specific or {}
+
+    def dict(self):
+        return {
+            'node_id': self.node_id,
+            'node_type': self.node_type,
+            'creation_timestamp': self.creation_timestamp,
+            'last_modified_timestamp': self.last_modified_timestamp,
+            'salience_score': self.salience_score,
+            'cognitive_thread_id_ref': self.cognitive_thread_id_ref,
+            'internal_code_chunk_ref': self.internal_code_chunk_ref,
+            'embedded_context': self.embedded_context,
+            'type_specific': self.type_specific,
+        }
+
+class ETGGraph:
+    def __init__(self, meta=None, nodes=None, edges=None):
+        self.meta = meta or {}
+        self.nodes = nodes or []
+        self.edges = edges or []
+
+    def add_node(self, node_dict):
+        self.nodes.append(node_dict)
+        return node_dict

--- a/sandbox/__init__.py
+++ b/sandbox/__init__.py
@@ -1,0 +1,1 @@
+from .environment import GridEnvironment

--- a/sandbox/environment.py
+++ b/sandbox/environment.py
@@ -1,0 +1,21 @@
+class GridEnvironment:
+    """Simple 1D grid world where an agent seeks an object."""
+
+    def __init__(self, size=5, object_pos=3):
+        self.size = size
+        self.object_pos = object_pos
+        self.agent_pos = 0
+
+    def get_percept(self):
+        return 1 if self.agent_pos == self.object_pos else 0
+
+    def take_action(self, action):
+        if action == 'right' and self.agent_pos < self.size - 1:
+            self.agent_pos += 1
+        elif action == 'left' and self.agent_pos > 0:
+            self.agent_pos -= 1
+
+        percept = self.get_percept()
+        reward = 1.0 if percept else 0.0
+        done = percept == 1
+        return percept, reward, done


### PR DESCRIPTION
## Summary
- add stub modules for `ETGGraph`, `Node`, and `GridEnvironment`
- update demo to import local stubs via `sys.path`
- document how to run the demo offline
- ignore Python cache files

## Testing
- `python -m py_compile demo/demo_catalyst_adapt.py`
- `python demo/demo_catalyst_adapt.py`